### PR TITLE
Pass binary to `cast_attachments`

### DIFF
--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -36,6 +36,11 @@ defmodule Waffle.Ecto.Schema do
             # Allow casting Plug.Uploads
             {field, upload = %{__struct__: Plug.Upload}}, fields -> [{field, {upload, scope}} | fields]
 
+            # Allow casting binary data structs
+            {field, upload = %{filename: filename, binary: binary}}, fields
+              when is_binary(filename) and is_binary(binary) ->
+              [{field, {upload, scope}} | fields]
+
             # If casting a binary (path), ensure we've explicitly allowed paths
             {field, path}, fields when is_binary(path) ->
               cond do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -115,7 +115,7 @@ defmodule WaffleTest.Ecto.Schema do
   end
 
   test_with_mock "casting binary data struct attachments", DummyDefinition, [store: fn({%{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}, %TestUser{}}) -> {:ok, "file.png"} end] do
-    changeset = TestUser.changeset(%TestUser{}, %{"avatar" => %{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}})
+    TestUser.changeset(%TestUser{}, %{"avatar" => %{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}})
     assert called DummyDefinition.store({%{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}, %TestUser{}})
   end
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -113,4 +113,9 @@ defmodule WaffleTest.Ecto.Schema do
     TestUser.url_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
     assert not called DummyDefinition.store({"/path/to/my/file.png", %TestUser{}})
   end
+
+  test_with_mock "casting binary data struct attachments", DummyDefinition, [store: fn({%{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}, %TestUser{}}) -> {:ok, "file.png"} end] do
+    changeset = TestUser.changeset(%TestUser{}, %{"avatar" => %{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}})
+    assert called DummyDefinition.store({%{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}, %TestUser{}})
+  end
 end


### PR DESCRIPTION
to address the https://github.com/stavro/arc_ecto/pull/87 and https://github.com/stavro/arc_ecto/issues/54

from @azhi
arc allows storing `%{filename: filename, binary: data}`,
and now arc_ecto allows these structs to be accepted in
`cast_attachments`