### PR TITLE
Add option trim and prevent to try cast empty "" param

### DIFF
--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -44,6 +44,8 @@ defmodule Waffle.Ecto.Schema do
 
     * `:allow_urls` — fetches remote file if the string matches `~r/^https?:\/\//`
     * `:allow_paths` — accepts any local path as file destination
+    * `:trim` - a boolean that sets whether whitespaces are removed before
+      running the cast on binaries/strings, defaults to true
 
   ## Examples
 
@@ -106,9 +108,11 @@ defmodule Waffle.Ecto.Schema do
 
       # If casting a binary (path), ensure we've explicitly allowed paths
       {field, path}, fields when is_binary(path) ->
+        trim = Keyword.get(options, :trim, true)
+        path = if trim, do: String.trim(path), else: path
+
         cond do
-          Keyword.get(options, :allow_urls, false) and
-              Regex.match?(~r/^https?:\/\//, path) ->
+          Keyword.get(options, :allow_urls, false) and Regex.match?(~r/^https?:\/\//, path) ->
             [{field, {path, scope}} | fields]
 
           Keyword.get(options, :allow_paths, false) ->

--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -112,6 +112,9 @@ defmodule Waffle.Ecto.Schema do
         path = if trim, do: String.trim(path), else: path
 
         cond do
+          path == "" ->
+            fields
+
           Keyword.get(options, :allow_urls, false) and Regex.match?(~r/^https?:\/\//, path) ->
             [{field, {path, scope}} | fields]
 

--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -44,8 +44,6 @@ defmodule Waffle.Ecto.Schema do
 
     * `:allow_urls` — fetches remote file if the string matches `~r/^https?:\/\//`
     * `:allow_paths` — accepts any local path as file destination
-    * `:trim` - a boolean that sets whether whitespaces are removed before
-      running the cast on binaries/strings, defaults to true
 
   ## Examples
 
@@ -108,8 +106,7 @@ defmodule Waffle.Ecto.Schema do
 
       # If casting a binary (path), ensure we've explicitly allowed paths
       {field, path}, fields when is_binary(path) ->
-        trim = Keyword.get(options, :trim, true)
-        path = if trim, do: String.trim(path), else: path
+        path = String.trim(path)
 
         cond do
           path == "" ->

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -139,6 +139,15 @@ defmodule WaffleTest.Ecto.Schema do
     assert nil == Ecto.Changeset.get_field(changeset, :avatar)
   end
 
+  test_with_mock "casting empty attachments", DummyDefinition,
+    store: fn {"/path/to/my/file.png", %TestUser{}} ->
+      {:ok, "file.png"}
+    end do
+    changeset = TestUser.changeset(%TestUser{}, %{"avatar" => ""})
+    assert nil == Ecto.Changeset.get_field(changeset, :avatar)
+    assert not called(DummyDefinition.store({"/path/to/my/file.png", %TestUser{}}))
+  end
+
   test_with_mock "allow_paths => true", DummyDefinition,
     store: fn {"/path/to/my/file.png", %TestUser{}} -> {:ok, "file.png"} end do
     TestUser.path_changeset(%TestUser{}, %{"avatar" => "  /path/to/my/file.png  "})

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -39,13 +39,6 @@ defmodule WaffleTest.Ecto.Schema do
       |> cast(params, ~w(first_name)a)
       |> cast_attachments(params, ~w(avatar)a)
     end
-
-    def changeset_without_trim(user, params \\ :invalid) do
-      user
-      |> cast(params, ~w(first_name)a)
-      |> cast_attachments(params, ~w(avatar)a, trim: false, allow_paths: true, allow_urls: true)
-      |> validate_required(:avatar)
-    end
   end
 
   def build_upload(path) do
@@ -154,12 +147,6 @@ defmodule WaffleTest.Ecto.Schema do
     assert called(DummyDefinition.store({"/path/to/my/file.png", %TestUser{}}))
   end
 
-  test_with_mock "with disabled trim and allow_paths => true", DummyDefinition,
-    store: fn {"  /path/to/my/file.png  ", %TestUser{}} -> {:ok, "file.png"} end do
-    TestUser.changeset_without_trim(%TestUser{}, %{"avatar" => "  /path/to/my/file.png  "})
-    assert called(DummyDefinition.store({"  /path/to/my/file.png  ", %TestUser{}}))
-  end
-
   test_with_mock "allow_urls => true", DummyDefinition,
     store: fn {"http://external.url/file.png", %TestUser{}} ->
       {:ok, "file.png"}
@@ -174,17 +161,6 @@ defmodule WaffleTest.Ecto.Schema do
     end do
     TestUser.url_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
     assert not called(DummyDefinition.store({"/path/to/my/file.png", %TestUser{}}))
-  end
-
-  test_with_mock "with disabled trim and allow_urls => true", DummyDefinition,
-    store: fn {"  http://external.url/file.png  ", %TestUser{}} ->
-      {:ok, "file.png"}
-    end do
-    TestUser.changeset_without_trim(%TestUser{}, %{
-      "avatar" => "  http://external.url/file.png  "
-    })
-
-    assert called(DummyDefinition.store({"  http://external.url/file.png  ", %TestUser{}}))
   end
 
   test_with_mock "casting binary data struct attachments", DummyDefinition,

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -133,12 +133,10 @@ defmodule WaffleTest.Ecto.Schema do
   end
 
   test_with_mock "casting empty attachments", DummyDefinition,
-    store: fn {"/path/to/my/file.png", %TestUser{}} ->
-      {:ok, "file.png"}
-    end do
-    changeset = TestUser.changeset(%TestUser{}, %{"avatar" => ""})
+    store: fn {"", %TestUser{}} -> {:ok, ""} end do
+    changeset = TestUser.path_changeset(%TestUser{}, %{"avatar" => ""})
     assert nil == Ecto.Changeset.get_field(changeset, :avatar)
-    assert not called(DummyDefinition.store({"/path/to/my/file.png", %TestUser{}}))
+    assert not called(DummyDefinition.store({"", %TestUser{}}))
   end
 
   test_with_mock "allow_paths => true", DummyDefinition,


### PR DESCRIPTION
This PR adding:
- a new option `trim` with default value as `true` to remove all leading and trailing Unicode whitespaces from params before cast
- avoid trying to cast empty (`""`) params in the changeset