### PR TITLE
Add ability to update image with existing data

### DIFF
--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -99,6 +99,11 @@ defmodule Waffle.Ecto.Schema do
       {field, upload = %{__struct__: Plug.Upload}}, fields ->
         [{field, {upload, scope}} | fields]
 
+      # Allow update with data from schema
+      {field, data = %{file_name: filename}}, fields
+      when is_binary(filename) ->
+        [{field, {data, scope}} | fields]
+
       # Allow casting binary data structs
       {field, upload = %{filename: filename, binary: binary}}, fields
       when is_binary(filename) and is_binary(binary) ->

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -63,6 +63,16 @@ defmodule WaffleTest.Ecto.Schema do
     %{file_name: "file.png", updated_at: _} = cs.changes.avatar
   end
 
+  test_with_mock "supports updating with already existing data", DummyDefinition,
+    store: fn {_, %TestUser{}} ->
+      {:ok, "file.png"}
+    end do
+    attrs = %{"avatar" => build_upload("/path/to/my/file.png")}
+    cs = TestUser.changeset(%TestUser{}, attrs)
+    assert {:ok, user} = Ecto.Changeset.apply_action(cs, :insert)
+    TestUser.changeset(user, %{"avatar" => user.avatar})
+  end
+
   test_with_mock "cascades storage error into an error", DummyDefinition,
     store: fn {%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"},
                %TestUser{}} ->


### PR DESCRIPTION
Suppose you have a loaded struct with already saved image and you want
to put this image back into arguments. Now you are allowed to put this
image back into arguments and expect it will be stored there without
runtime errors.