### PR TITLE
Allow custom error messages to be set on cast

### DIFF
--- a/lib/waffle_ecto/type.ex
+++ b/lib/waffle_ecto/type.ex
@@ -19,9 +19,19 @@ defmodule Waffle.Ecto.Type do
 
   def cast(definition, args) do
     case definition.store(args) do
-      {:ok, file} -> {:ok, %{file_name: file, updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now, :second)}}
+      {:ok, file} ->
+        {:ok, %{file_name: file, updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)}}
+
+      {:error, message} = error when is_binary(message) ->
+        log_error(error)
+        {:error, [message: message]}
+
+      {:error, [message: message]} = error ->
+        log_error(error)
+        {:error, [message: message]}
+
       error ->
-        Logger.error(inspect(error))
+        log_error(error)
         :error
     end
   end
@@ -61,4 +71,6 @@ defmodule Waffle.Ecto.Type do
   def dump(definition, %{"file_name" => file_name, "updated_at" => updated_at}) do
     dump(definition, %{file_name: file_name, updated_at: updated_at})
   end
+
+  defp log_error(error), do: Logger.error(inspect(error))
 end


### PR DESCRIPTION
This PR goes hand in hand with https://github.com/elixir-waffle/waffle/pull/84.

This allows custom messages to be set on cast errors.