### PR TITLE
Fix Waffle.Ecto.Type load and dump in embeds

### DIFF
--- a/lib/waffle_ecto/definition.ex
+++ b/lib/waffle_ecto/definition.ex
@@ -56,6 +56,7 @@ defmodule Waffle.Ecto.Definition do
         def cast(value), do: Waffle.Ecto.Type.cast(unquote(definition), value)
         def load(value), do: Waffle.Ecto.Type.load(unquote(definition), value)
         def dump(value), do: Waffle.Ecto.Type.dump(unquote(definition), value)
+        def embed_as(format), do: Waffle.Ecto.Type.embed_as(unquote(definition), format)
       end
 
       def url({%{file_name: file_name, updated_at: updated_at}, scope}, version, options) do

--- a/lib/waffle_ecto/type.ex
+++ b/lib/waffle_ecto/type.ex
@@ -72,5 +72,7 @@ defmodule Waffle.Ecto.Type do
     dump(definition, %{file_name: file_name, updated_at: updated_at})
   end
 
+  def embed_as(_definition, _format), do: :dump
+
   defp log_error(error), do: Logger.error(inspect(error))
 end

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -37,4 +37,30 @@ defmodule WaffleTest.Ecto.Type do
     {:ok, dumped_type} = DummyDefinition.Type.dump(value)
     assert dumped_type == "file.png"
   end
+
+  test "dumps as embedded type to a string" do
+    timestamp = NaiveDateTime.from_erl!({{1970, 1, 1}, {0, 0, 0}})
+
+    assert {:ok, value} =
+      Ecto.Type.embedded_dump(
+        DummyDefinition.Type,
+        %{file_name: "file.png", updated_at: timestamp},
+        :json
+      )
+
+    assert value == "file.png?62167219200"
+  end
+
+  test "loads as embedded type from a string" do
+    timestamp = NaiveDateTime.from_erl!({{1970, 1, 1}, {0, 0, 0}})
+
+    assert {:ok, value} =
+      Ecto.Type.embedded_load(
+        DummyDefinition.Type,
+        "file.png?62167219200",
+        :json
+      )
+
+    assert value == %{file_name: "file.png", updated_at: timestamp}
+  end
 end


### PR DESCRIPTION
- fixes elixir-waffle/waffle_ecto#19

By default Ecto uses :self strategy which encodes the type without calling load/1 or dump/1 on custom type. So Waffle.Ecto.Type was encoded and decoded as a json, with native Ecto tools -> it was stored as an actual json in DB instead of using `filename_with_timestamp` string representation defined in Waffle.Ecto.Type

BREAKING CHANGE: this commit will "break" loading existing embedded fieds from DB that used previous waffle versions. Now Waffle.Ecto.Type expects `value` to be a string, but old representation will feed it a map. Depending on your ecto adapter, you can fix it by: a) re-dumping all values to your db properly
b) adding Waffle.Ecto.Type.load/2 for a json Map values and parsing "updated_at" map value to NaiveDateTime from a representation specific to your adapter

---

@achempion I'm not sure how you approach breaking changes in this project, but I believe handling old (and wrong) data representation inside the library would be messy, so I didn't. E.g. we would end up having code like

```elixir
  defp properly_parse_old_representation_for_ecto_adapter(...) do
    # I guess this function will heavily depend on a specific ecto adapter client uses
    ...
  end

  def load(definition, %{file_name: file_name, updated_at: updated_at}) do
    load(definition, %{"file_name" => file_name, "updated_at" => updated_at})
  end

  def load(_definition, %{"file_name" => file_name, "updated_at" => updated_at}) do
    ndt = properly_parse_old_representation_for_ecto_adapter(updated_at)
    {:ok, %{file_name: file_name, updated_at: ndt}}
  end
```

Seems like it's better to tell lib users who need this to handle their specific situation properly.
I'm not an expert in elixir or ecto though, so if someone knows a better way to make this backward compatible - feel free to add more commits.