### PR TITLE
Make Logger optional

### DIFF
--- a/lib/waffle_ecto/logger.ex
+++ b/lib/waffle_ecto/logger.ex
@@ -3,8 +3,6 @@ defmodule WaffleEcto.Logger do
 
   @callback log(level :: level(), message :: binary) :: :ok
 
-  @adapter Application.compile_env(:waffle_ecto, :log_adapter, WaffleEcto.Logger.Default)
-
   @doc ~S"""
   Log a message using the log adapter.
   This function expect an atom representing the level (`:info`, `:warning`, `:error`) and a message.
@@ -44,6 +42,10 @@ defmodule WaffleEcto.Logger do
   """
   @spec log(level :: level, message :: binary()) :: :ok
   def log(level, message) do
-    @adapter.log(level, message)
+    adapter().log(level, message)
+  end
+
+  defp adapter do
+    Application.get_env(:waffle_ecto, :log_adapter, WaffleEcto.Logger.Default)
   end
 end

--- a/lib/waffle_ecto/logger.ex
+++ b/lib/waffle_ecto/logger.ex
@@ -1,0 +1,49 @@
+defmodule WaffleEcto.Logger do
+  @type level :: :info | :warning | :error
+
+  @callback log(level :: level(), message :: binary) :: :ok
+
+  @adapter Application.compile_env(:waffle_ecto, :log_adapter, WaffleEcto.Logger.Default)
+
+  @doc ~S"""
+  Log a message using the log adapter.
+  This function expect an atom representing the level (`:info`, `:warning`, `:error`) and a message.
+
+  The logger will be fetch from the application configuration.
+
+  ```elixir
+  config :waffle_ecto, :log_adapter, WaffleEcto.Logger.Default
+  ```
+
+  By default it will use the Default logger which use the Elixir Logger module.
+
+  You can define you own adapter by adding `@behaviour WaffleEcto.Logger` to your adapter module
+  and defining the callback `log/2`.
+
+  ```elixir
+  defmodule MyAdapter do
+    @behaviour Waffle.Ecto
+
+    def log(level, message) do
+      #do something
+    end
+  end
+  ```
+
+  You can avoid logging messages by using adding this to your config file:
+
+  ```elixir
+  config :waffle_ecto, :log_adapter, WaffleEcto.Logger.None
+  ```
+
+  ## Examples
+
+      log(:warning, "Large file size")
+      log(:error, "Invalid file extensions")
+
+  """
+  @spec log(level :: level, message :: binary()) :: :ok
+  def log(level, message) do
+    @adapter.log(level, message)
+  end
+end

--- a/lib/waffle_ecto/logger/default.ex
+++ b/lib/waffle_ecto/logger/default.ex
@@ -1,0 +1,9 @@
+defmodule WaffleEcto.Logger.Default do
+  @behaviour WaffleEcto.Logger
+
+  require Logger
+
+  def log(:info, message), do: Logger.info(message)
+  def log(:warning, message), do: Logger.warning(message)
+  def log(:error, message), do: Logger.error(message)
+end

--- a/lib/waffle_ecto/logger/none.ex
+++ b/lib/waffle_ecto/logger/none.ex
@@ -1,0 +1,7 @@
+defmodule WaffleEcto.Logger.None do
+  @behaviour WaffleEcto.Logger
+
+  def log(_, _) do
+    :ok
+  end
+end

--- a/lib/waffle_ecto/type.ex
+++ b/lib/waffle_ecto/type.ex
@@ -3,8 +3,6 @@ defmodule Waffle.Ecto.Type do
   Provides implementation for custom Ecto.Type behaviour.
   """
 
-  require Logger
-
   def type, do: :string
 
   @filename_with_timestamp ~r{^(.*)\?(\d+)$}
@@ -72,5 +70,5 @@ defmodule Waffle.Ecto.Type do
     dump(definition, %{file_name: file_name, updated_at: updated_at})
   end
 
-  defp log_error(error), do: Logger.error(inspect(error))
+  defp log_error(error), do: WaffleEcto.Logger.log(:error, inspect(error))
 end


### PR DESCRIPTION
In this PR I wanted to introduce the possibility to swap the Logger implementation so that users can decide how WaffleEcto will log potential errors. 

Having error log from an external library is not always wanted in production project and some might want to have control over that. 

This PR gives now the ability to disable the error logs by adding this to a config file

```elixir
config :waffle_ecto, :log_adapter, WaffleEcto.Logger.None
```

Note : I wanted to go the extra mile and add make this extendable using `@callback` instead of just adding a boolean to enable, disabled log. I think it might be useful but it also add more bit more code and I don't know if it will be used for anything else than disabling / enabling the log so.. 😄 
