### PR TITLE
Check for non-empty params and return changeset in cast_attachments

### DIFF
--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -81,11 +81,7 @@ defmodule Waffle.Ecto.Schema do
           Ecto.Changeset.cast(changeset_or_data, waffle_params, allowed)
 
         _ ->
-          Ecto.Changeset.add_error(
-            changeset_or_data,
-            :missing_attachment,
-            "no attachment(s) given to cast"
-          )
+          changeset_or_data
       end
     end
   end

--- a/lib/waffle_ecto/schema.ex
+++ b/lib/waffle_ecto/schema.ex
@@ -21,7 +21,7 @@ defmodule Waffle.Ecto.Schema do
           field :avatar, MyApp.Uploaders.AvatarUploader.Type
         end
 
-        def changeset(user, params \\ :invalid) do
+        def changeset(user, params \\ %{}) do
           user
           |> cast(params, [:name])
           |> cast_attachments(params, [:avatar])
@@ -69,20 +69,24 @@ defmodule Waffle.Ecto.Schema do
           end
         end)
 
-      waffle_params =
-        case params do
-          :invalid ->
-            :invalid
-
-          %{} ->
+      case params do
+        params when is_map(params) and map_size(params) > 0 ->
+          waffle_params =
             params
             |> convert_params_to_binary()
             |> Map.take(allowed_param_keys)
             |> check_and_apply_scope(scope, options)
             |> Enum.into(%{})
-        end
 
-      Ecto.Changeset.cast(changeset_or_data, waffle_params, allowed)
+          Ecto.Changeset.cast(changeset_or_data, waffle_params, allowed)
+
+        _ ->
+          Ecto.Changeset.add_error(
+            changeset_or_data,
+            :missing_attachment,
+            "no attachment(s) given to cast"
+          )
+      end
     end
   end
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -45,11 +45,15 @@ defmodule WaffleTest.Ecto.Schema do
     %{__struct__: Plug.Upload, path: path, filename: Path.basename(path)}
   end
 
-  test "supports :invalid changeset" do
+  test "supports invalid empty changeset" do
     cs = TestUser.changeset(%TestUser{})
     assert cs.valid? == false
     assert cs.changes == %{}
-    assert cs.errors == [avatar: {"can't be blank", [validation: :required]}]
+
+    assert cs.errors == [
+             avatar: {"can't be blank", [validation: :required]},
+             missing_attachment: {"no attachment(s) given to cast", []}
+           ]
   end
 
   test_with_mock "cascades storage success into a valid change", DummyDefinition,

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -49,11 +49,7 @@ defmodule WaffleTest.Ecto.Schema do
     cs = TestUser.changeset(%TestUser{})
     assert cs.valid? == false
     assert cs.changes == %{}
-
-    assert cs.errors == [
-             avatar: {"can't be blank", [validation: :required]},
-             missing_attachment: {"no attachment(s) given to cast", []}
-           ]
+    assert cs.errors == [avatar: {"can't be blank", [validation: :required]}]
   end
 
   test_with_mock "cascades storage success into a valid change", DummyDefinition,


### PR DESCRIPTION
Closes #54

Previously, the documentation stated a default of `:invalid` for the changeset function (and in extension the cast_attachments function).

```
def changeset(user, params \\ :invalid) do
```

The `cast_attachments` function would then check the params for `:invalid` and return `:invalid`, which would get passed to the `Ecto.Changeset.cast` function as the params argument.
```
waffle_params =
  case params do
    :invalid ->
      :invalid

[...]

Ecto.Changeset.cast(changeset_or_data, waffle_params, allowed)
```

Since the improved type checking of Elixir 1.18 this causes a typespec warning, since the `Changeset.cast` function's signature does not specify `:invalid` as a valid type for the params.

Solved by checking if the params are a non-empty map and returning a proper Changeset error:

```
case params do
  params when is_map(params) and map_size(params) > 0 ->
    [...]
    Ecto.Changeset.cast(changeset_or_data, waffle_params, allowed)

  _ ->
    Ecto.Changeset.add_error(
      changeset_or_data,
      :missing_attachment,
      "no attachment(s) given to cast"
    )
```